### PR TITLE
style(csrf.ts): rename xsrf-token cookie name to XSRF-TOKEN

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            November 28th 2020, 10:11:46 am
+                            January 12th 2021, 3:38:53 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/csrf.ts
+++ b/src/csrf.ts
@@ -89,7 +89,7 @@ export class Csrf {
 	 * - `_csrf` input
 	 * - `x-csrf-token` header
 	 * - Or `x-xsrf-token` header. The header value must be set by
-	 *   reading the `xsrf-token` cookie.
+	 *   reading the `XSRF-TOKEN` cookie.
 	 */
 	private getCsrfTokenFromRequest(request: RequestContract): string | null {
 		const token = request.input('_csrf', request.header('x-csrf-token'))
@@ -110,7 +110,7 @@ export class Csrf {
 			return null
 		}
 
-		return this.encryption.decrypt(decodeURIComponent(encryptedToken).slice(2), 'xsrf-token')
+		return this.encryption.decrypt(decodeURIComponent(encryptedToken).slice(2), 'XSRF-TOKEN')
 	}
 
 	/**
@@ -190,7 +190,7 @@ export class Csrf {
 			const cookieOptions = Object.assign({}, this.options.cookieOptions, {
 				httpOnly: false,
 			})
-			ctx.response.encryptedCookie('xsrf-token', ctx.request.csrfToken, cookieOptions)
+			ctx.response.encryptedCookie('XSRF-TOKEN', ctx.request.csrfToken, cookieOptions)
 		}
 
 		/**

--- a/test/csrf.spec.ts
+++ b/test/csrf.spec.ts
@@ -205,7 +205,7 @@ test.group('Csrf', (group) => {
 		ctx.request.request.headers = {
 			'x-xsrf-token': `e:${app.container
 				.use('Adonis/Core/Encryption')
-				.encrypt(csrfToken, undefined, 'xsrf-token')!}`,
+				.encrypt(csrfToken, undefined, 'XSRF-TOKEN')!}`,
 		}
 
 		await csrf(ctx)
@@ -334,7 +334,7 @@ test.group('Csrf', (group) => {
 		ctx.request.request.headers = {
 			'x-xsrf-token': `e:${app.container
 				.use('Adonis/Core/Encryption')
-				.encrypt(csrfToken, undefined, 'xsrf-token')}`,
+				.encrypt(csrfToken, undefined, 'XSRF-TOKEN')}`,
 		}
 
 		try {
@@ -431,7 +431,7 @@ test.group('Csrf', (group) => {
 		assert.equal(
 			app.container
 				.use('Adonis/Core/Encryption')
-				.decrypt(cookie.replace('xsrf-token=e:', ''), 'xsrf-token'),
+				.decrypt(cookie.replace('XSRF-TOKEN=e:', ''), 'XSRF-TOKEN'),
 			ctx.request.csrfToken
 		)
 	})


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Rename the XSRF-TOKEN cookie name that AdonisJS send in the response, so it'll match what is written in the documentation and in the template.
Detailed context I've been through to make this PR: https://github.com/adonisjs/core/discussions/2078
After I made this PR, I saw that this can solve this open issue: https://github.com/adonisjs/shield/issues/22#issue-777360231

## Types of changes

What types of changes does your code introduce?

- [x] Style (not a bug, nor a feature, just renaming the cookie)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/shield/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.

=> I have tested locally in my project. Before this commit, I had to add `xsrfCookieName: 'xsrf-token'` in axios instance, so axios could read the cookie that AdonisJS send. After this commit, I could remove this configuration and axios works like expected.
- [x] I have added necessary documentation (if appropriate) (documentation is already right, code wasn't)

## Further comments

When following the guide in https://preview.adonisjs.com/guides/csrf-protection, it's understood that when you enable `enableXsrfCookie`, AdonisJS will set a cookie named `XSRF-TOKEN`.

Futhermore, the template (shield.txt) says the following "When the following flag is enabled, AdoniJS will drop
`XSRF-TOKEN` cookie [...]".

But all that doesn't happen, Adonis sets a cookie named `xsrf-token` and a library like axios doesn't recognize it and a manual intervention is needed to axios works with AdonisJS.

So, this PR changes that. And when further users read the documentation about CSRF protection, they won't need to figure out why axios is not sending the cookie.
