### PR TITLE
fix: 🐛 add missing parentheses in exceptRoutes code sample

### DIFF
--- a/templates/shield.txt
+++ b/templates/shield.txt
@@ -89,7 +89,7 @@ export const csrf: ShieldConfig['csrf'] = {
 	|
 	| Also you can define a function that is evaluated on every HTTP Request.
 	| ```
-	|  exceptRoutes: ({ request }) => request.url.includes('/api')
+	|  exceptRoutes: ({ request }) => request.url().includes('/api')
 	| ```
   |
   */


### PR DESCRIPTION
✅ Closes: #29