### PR TITLE
fix: incorrect link for content-type sniffing header

### DIFF
--- a/templates/shield.txt
+++ b/templates/shield.txt
@@ -230,7 +230,7 @@ export const hsts: ShieldConfig['hsts'] = {
 | files with .txt extension containing Javascript code will be executed as
 | Javascript. You can disable this behavior by setting nosniff to false.
 |
-| Learn more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+| Learn more at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
 |
 */
 export const contentTypeSniffing: ShieldConfig['contentTypeSniffing'] = {


### PR DESCRIPTION
## Proposed changes

Fix incorrect link in a comment

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/shield/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
