### PR TITLE
Remove unused import in chield config

### DIFF
--- a/templates/shield.txt
+++ b/templates/shield.txt
@@ -5,7 +5,6 @@
  * file.
  */
 
-import Env from '@ioc:Adonis/Core/Env'
 import { ShieldConfig } from '@ioc:Adonis/Addons/Shield'
 
 /*


### PR DESCRIPTION
The unused import from chield config will break the the build script.

### How to reproduce the error.

* `yarn create adonis-ts-app hello-world`
  * Select the project structure -> `web`
  * For the rest options simple `ENTER`
* `cd hello-world`
* `yarn build`

<img width="1298" alt="CleanShot 2022-11-26 at 00 45 10@2x" src="https://user-images.githubusercontent.com/6713842/204063674-8326935c-f1f2-49a4-8c2e-ca97f5399e44.png">


## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/shield/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
