### PR TITLE
Add @japa/api-client 2.x and 3.x as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@adonisjs/core": "^6.2.0",
     "@adonisjs/i18n": "^2.0.0",
     "@adonisjs/session": "^7.0.0",
-    "@japa/api-client": "^2.0.2",
+    "@japa/api-client": "^2.0.2 || ^3.0.0",
     "edge.js": "^6.0.1"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Dependency Update

### 📚 Description
Add `@japa/api-client` version `3.x` as a peer dependency. This may raise the question if the `@japa/api-client` should be listed in peer dependencies because it requires someone to add any new major version when released. I’m not familiar with peer dependencies in modern npm versions. Maybe it’s enough to have `@japa/api-client` as a dev dependency.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
